### PR TITLE
Rename package to jupyter-scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-About jupyter_scheduler-feedstock
+About jupyter-scheduler-feedstock
 =================================
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/jupyter_scheduler-feedstock/blob/main/LICENSE.txt)
@@ -27,53 +27,53 @@ Current release info
 
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-jupyter_scheduler-green.svg)](https://anaconda.org/conda-forge/jupyter_scheduler) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/jupyter_scheduler.svg)](https://anaconda.org/conda-forge/jupyter_scheduler) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/jupyter_scheduler.svg)](https://anaconda.org/conda-forge/jupyter_scheduler) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/jupyter_scheduler.svg)](https://anaconda.org/conda-forge/jupyter_scheduler) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-jupyter--scheduler-green.svg)](https://anaconda.org/conda-forge/jupyter-scheduler) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/jupyter-scheduler.svg)](https://anaconda.org/conda-forge/jupyter-scheduler) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/jupyter-scheduler.svg)](https://anaconda.org/conda-forge/jupyter-scheduler) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/jupyter-scheduler.svg)](https://anaconda.org/conda-forge/jupyter-scheduler) |
 
-Installing jupyter_scheduler
+Installing jupyter-scheduler
 ============================
 
-Installing `jupyter_scheduler` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `jupyter-scheduler` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
 
 ```
 conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `jupyter_scheduler` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `jupyter-scheduler` can be installed with `conda`:
 
 ```
-conda install jupyter_scheduler
-```
-
-or with `mamba`:
-
-```
-mamba install jupyter_scheduler
-```
-
-It is possible to list all of the versions of `jupyter_scheduler` available on your platform with `conda`:
-
-```
-conda search jupyter_scheduler --channel conda-forge
+conda install jupyter-scheduler
 ```
 
 or with `mamba`:
 
 ```
-mamba search jupyter_scheduler --channel conda-forge
+mamba install jupyter-scheduler
+```
+
+It is possible to list all of the versions of `jupyter-scheduler` available on your platform with `conda`:
+
+```
+conda search jupyter-scheduler --channel conda-forge
+```
+
+or with `mamba`:
+
+```
+mamba search jupyter-scheduler --channel conda-forge
 ```
 
 Alternatively, `mamba repoquery` may provide more information:
 
 ```
 # Search all versions available on your platform:
-mamba repoquery search jupyter_scheduler --channel conda-forge
+mamba repoquery search jupyter-scheduler --channel conda-forge
 
-# List packages depending on `jupyter_scheduler`:
-mamba repoquery whoneeds jupyter_scheduler --channel conda-forge
+# List packages depending on `jupyter-scheduler`:
+mamba repoquery whoneeds jupyter-scheduler --channel conda-forge
 
-# List dependencies of `jupyter_scheduler`:
-mamba repoquery depends jupyter_scheduler --channel conda-forge
+# List dependencies of `jupyter-scheduler`:
+mamba repoquery depends jupyter-scheduler --channel conda-forge
 ```
 
 
@@ -118,17 +118,17 @@ Terminology
                   produce the finished article (built conda distributions)
 
 
-Updating jupyter_scheduler-feedstock
+Updating jupyter-scheduler-feedstock
 ====================================
 
-If you would like to improve the jupyter_scheduler recipe or build a new
+If you would like to improve the jupyter-scheduler recipe or build a new
 package version, please fork this repository and submit a PR. Upon submission,
 your changes will be run on the appropriate platforms to give the reviewer an
 opportunity to confirm that the changes result in a successful build. Once
 merged, the recipe will be re-built and uploaded automatically to the
 `conda-forge` channel, whereupon the built conda packages will be available for
 everybody to install and use from the `conda-forge` channel.
-Note that all branches in the conda-forge/jupyter_scheduler-feedstock are
+Note that all branches in the conda-forge/jupyter-scheduler-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
 on branches in forks and branches in the main repository should only be used to
 build distinct package versions.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set name = "jupyter_scheduler" %}
+{% set name = "jupyter-scheduler" %}
 {% set version = "2.1.0" %}
 
 package:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* N/A as we are changing the package name. Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

### Problem 

Currently `main` branch of this feedstock repo has package name `jupyter_scheduler` while 1.x branch `jupyter-scheduler`.

Github [repo `jupyter-scheduler`](https://github.com/jupyter-server/jupyter-scheduler)
 says "This extension is composed of a Python package named `jupyter_scheduler` for the server extension and a NPM package named `@jupyterlab/scheduler` for the frontend extension." and asks to use `pip install jupyter_scheduler` to install the extension. It's not clear if `jupyter_scheduler` or `jupyter-scheduler` is the name of the extension / package. 

### Proposed solution

Use jupyter-scheduler as a Jupyter Scheduler package name, use `jupyter_scheduler` to refer to the server component. This would be in line with how package is named [at PyPi website](https://pypi.org/project/jupyter-scheduler/), how jupyter-ai package is [named at conda-forge](https://anaconda.org/search?q=jupyter-ai).

This PR updates a `set name `in the recipe which will make 2.1.0 available at conda-forge under `jupyter-scheduler`. 

Next steps after this PR is approved:
- Mark conda-forge `jupyter_scheduler` package as broken following steps outlined in the [docs](https://conda-forge.org/docs/maintainer/updating_pkgs.html#removing-broken-packages)
- Update all packages that use conda-forge Jupyter Scheduler as a dependency to use correct package name `jupyter-scheduler`
- Update [Jupyter Scheduler Github](https://github.com/jupyter-server/jupyter-scheduler#readme) to use` jupyter-scheduler` as a package name (for example, when providing pip install commands)