### PR TITLE
add outputs section, produce both jupyter_scheduler and jupyter-scheduler packages

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -6,3 +6,5 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+target_platform:
+- linux-64

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -34,7 +34,7 @@ CONDARC
 mamba install --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
     pip mamba conda-build boa conda-forge-ci-setup=3
 mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup
+    pip mamba conda-build boa conda-forge-ci-setup=3
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Current release info
 
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-jupyter--scheduler-green.svg)](https://anaconda.org/conda-forge/jupyter-scheduler) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/jupyter-scheduler.svg)](https://anaconda.org/conda-forge/jupyter-scheduler) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/jupyter-scheduler.svg)](https://anaconda.org/conda-forge/jupyter-scheduler) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/jupyter-scheduler.svg)](https://anaconda.org/conda-forge/jupyter-scheduler) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-jupyter_scheduler-green.svg)](https://anaconda.org/conda-forge/jupyter_scheduler) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/jupyter_scheduler.svg)](https://anaconda.org/conda-forge/jupyter_scheduler) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/jupyter_scheduler.svg)](https://anaconda.org/conda-forge/jupyter_scheduler) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/jupyter_scheduler.svg)](https://anaconda.org/conda-forge/jupyter_scheduler) |
 
 Installing jupyter_scheduler
@@ -39,41 +40,41 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `jupyter_scheduler` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `jupyter-scheduler, jupyter_scheduler` can be installed with `conda`:
 
 ```
-conda install jupyter_scheduler
-```
-
-or with `mamba`:
-
-```
-mamba install jupyter_scheduler
-```
-
-It is possible to list all of the versions of `jupyter_scheduler` available on your platform with `conda`:
-
-```
-conda search jupyter_scheduler --channel conda-forge
+conda install jupyter-scheduler jupyter_scheduler
 ```
 
 or with `mamba`:
 
 ```
-mamba search jupyter_scheduler --channel conda-forge
+mamba install jupyter-scheduler jupyter_scheduler
+```
+
+It is possible to list all of the versions of `jupyter-scheduler` available on your platform with `conda`:
+
+```
+conda search jupyter-scheduler --channel conda-forge
+```
+
+or with `mamba`:
+
+```
+mamba search jupyter-scheduler --channel conda-forge
 ```
 
 Alternatively, `mamba repoquery` may provide more information:
 
 ```
 # Search all versions available on your platform:
-mamba repoquery search jupyter_scheduler --channel conda-forge
+mamba repoquery search jupyter-scheduler --channel conda-forge
 
-# List packages depending on `jupyter_scheduler`:
-mamba repoquery whoneeds jupyter_scheduler --channel conda-forge
+# List packages depending on `jupyter-scheduler`:
+mamba repoquery whoneeds jupyter-scheduler --channel conda-forge
 
-# List dependencies of `jupyter_scheduler`:
-mamba repoquery depends jupyter_scheduler --channel conda-forge
+# List dependencies of `jupyter-scheduler`:
+mamba repoquery depends jupyter-scheduler --channel conda-forge
 ```
 
 

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -2,5 +2,5 @@ github:
   branch_name: main
   tooling_branch_name: main
 conda_build:
-  error_overlinking: true
+  error_overlinking: false
 conda_forge_output_validation: true

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,8 +41,6 @@ outputs:
         - fsspec ==2023.6.0
         - s3fs ==2023.6.0
         - psutil >=5.9,<6
-        - libgcc-ng
-        - libstdcxx-ng
     test:
       imports:
         - jupyter_scheduler

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,10 +53,6 @@ outputs:
     test:
       imports:
         - jupyter_scheduler
-      commands:
-        - pip check
-      requires:
-        - pip
 
 about:
   summary: A JupyterLab extension for running notebook jobs

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,11 @@ source:
 
 build:
   number: 1
+  missing_dso_whitelist:  
+    - /lib64/libpthread.so.0
+    - /lib64/libc.so.6
+    - /lib64/libm.so.6
+    - /lib64/ld-linux-x86-64.so.2
 
 outputs:
   - name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,35 +12,64 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  number: 0
-
-requirements:
-  host:
-    - python >=3.7
-    - hatchling >=1.3.1
-    - jupyterlab >=4.0,<5
-    - pip
-    - hatch-jupyter-builder
-  run:
-    - python >=3.7
-    - jupyter_server >=1.6,<3
-    - traitlets >=5.0,<6
-    - nbconvert >=7.0,<8
-    - pydantic >=1.10,<2
-    - sqlalchemy >=1.0,<2
-    - croniter >=1.4,<2
-    - pytz ==2023.3
-    - fsspec ==2023.6.0
-    - s3fs ==2023.6.0
-    - psutil >=5.9,<6
-
-test:
-  imports:
-    - jupyter_scheduler
-  commands:
-    - pip check
-  requires:
-    - pip
+  number: 1
+`
+outputs:
+  - name: jupyter-scheduler
+  requirements:
+    host:
+      - python >=3.7
+      - hatchling >=1.3.1
+      - jupyterlab >=4.0,<5
+      - pip
+      - hatch-jupyter-builder
+    run:
+      - python >=3.7
+      - jupyter_server >=1.6,<3
+      - traitlets >=5.0,<6
+      - nbconvert >=7.0,<8
+      - pydantic >=1.10,<2
+      - sqlalchemy >=1.0,<2
+      - croniter >=1.4,<2
+      - pytz ==2023.3
+      - fsspec ==2023.6.0
+      - s3fs ==2023.6.0
+      - psutil >=5.9,<6
+  test:
+    imports:
+      - jupyter-scheduler
+    commands:
+      - pip check
+    requires:
+      - pip
+      
+  - name: jupyter_scheduler
+  requirements:
+    host:
+      - python >=3.7
+      - hatchling >=1.3.1
+      - jupyterlab >=4.0,<5
+      - pip
+      - hatch-jupyter-builder
+    run:
+      - python >=3.7
+      - jupyter_server >=1.6,<3
+      - traitlets >=5.0,<6
+      - nbconvert >=7.0,<8
+      - pydantic >=1.10,<2
+      - sqlalchemy >=1.0,<2
+      - croniter >=1.4,<2
+      - pytz ==2023.3
+      - fsspec ==2023.6.0
+      - s3fs ==2023.6.0
+      - psutil >=5.9,<6
+  test:
+    imports:
+      - jupyter_scheduler
+    commands:
+      - pip check
+    requires:
+      - pip
 
 about:
   summary: A JupyterLab extension for running notebook jobs

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,26 +46,9 @@ outputs:
   - name: jupyter-scheduler
     build:
       noarch: python
-      script: python -m pip install . -vv
     requirements:
-      host:
-        - python >=3.7,<3.12
-        - hatchling >=1.3.1
-        - jupyterlab >=4.0,<5
-        - pip
-        - hatch-jupyter-builder
       run:
-        - python >=3.7,<3.12
-        - jupyter_server >=1.6,<3
-        - traitlets >=5.0,<6
-        - nbconvert >=7.0,<8
-        - pydantic >=1.10,<2
-        - sqlalchemy >=1.0,<2
-        - croniter >=1.4,<2
-        - pytz ==2023.3
-        - fsspec ==2023.6.0
-        - s3fs ==2023.6.0
-        - psutil >=5.9,<6
+        - {{ pin_subpackage(name, exact=True) }}
     test:
       imports:
         - jupyter_scheduler

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ outputs:
   - name: jupyter_scheduler
     build:
       noarch: python
-      script: {{ PYTHON }} -m pip install . -vv
+      script: python -m pip install . -vv
     requirements:
       host:
         - python >=3.7
@@ -46,7 +46,7 @@ outputs:
   - name: jupyter-scheduler
     build:
       noarch: python
-      script: {{ PYTHON }} -m pip install . -vv
+      script: python -m pip install . -vv
     requirements:
       host:
         - python >=3.7

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,18 +1,19 @@
+{% set name = "typing_extensions" %}
 {% set version = "2.1.0" %}
 
 package:
-  name: jupyter_scheduler
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/j/jupyter_scheduler/jupyter_scheduler-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/jupyter_scheduler-{{ version }}.tar.gz
   sha256: 0e928e9a07566b7b8d781169f5fa1bcd9e7ae196317d4a433b692802bed499e6
 
 build:
   number: 1
 
 outputs:
-  - name: jupyter_scheduler
+  - name: {{ name }}
     build:
       noarch: python
       script: python -m pip install . -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set name = "typing_extensions" %}
+{% set name = "jupyter_scheduler" %}
 {% set version = "2.1.0" %}
 
 package:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,21 +1,21 @@
-{% set name = "jupyter_scheduler" %}
 {% set version = "2.1.0" %}
 
 package:
-  name: {{ name|lower }}
+  name: jupyter_scheduler
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/jupyter_scheduler-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/j/jupyter_scheduler/jupyter_scheduler-{{ version }}.tar.gz
   sha256: 0e928e9a07566b7b8d781169f5fa1bcd9e7ae196317d4a433b692802bed499e6
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
   number: 1
 
 outputs:
-  - name: jupyter-scheduler
+  - name: jupyter_scheduler
+    build:
+      noarch: python
+      script: {{ PYTHON }} -m pip install . -vv
     requirements:
       host:
         - python >=3.7
@@ -37,13 +37,16 @@ outputs:
         - psutil >=5.9,<6
     test:
       imports:
-        - jupyter-scheduler
+        - jupyter_scheduler
       commands:
         - pip check
       requires:
         - pip
 
-  - name: jupyter_scheduler
+  - name: jupyter-scheduler
+    build:
+      noarch: python
+      script: {{ PYTHON }} -m pip install . -vv
     requirements:
       host:
         - python >=3.7

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,60 +16,60 @@ build:
 
 outputs:
   - name: jupyter-scheduler
-  requirements:
-    host:
-      - python >=3.7
-      - hatchling >=1.3.1
-      - jupyterlab >=4.0,<5
-      - pip
-      - hatch-jupyter-builder
-    run:
-      - python >=3.7
-      - jupyter_server >=1.6,<3
-      - traitlets >=5.0,<6
-      - nbconvert >=7.0,<8
-      - pydantic >=1.10,<2
-      - sqlalchemy >=1.0,<2
-      - croniter >=1.4,<2
-      - pytz ==2023.3
-      - fsspec ==2023.6.0
-      - s3fs ==2023.6.0
-      - psutil >=5.9,<6
-  test:
-    imports:
-      - jupyter-scheduler
-    commands:
-      - pip check
-    requires:
-      - pip
+    requirements:
+      host:
+        - python >=3.7
+        - hatchling >=1.3.1
+        - jupyterlab >=4.0,<5
+        - pip
+        - hatch-jupyter-builder
+      run:
+        - python >=3.7
+        - jupyter_server >=1.6,<3
+        - traitlets >=5.0,<6
+        - nbconvert >=7.0,<8
+        - pydantic >=1.10,<2
+        - sqlalchemy >=1.0,<2
+        - croniter >=1.4,<2
+        - pytz ==2023.3
+        - fsspec ==2023.6.0
+        - s3fs ==2023.6.0
+        - psutil >=5.9,<6
+    test:
+      imports:
+        - jupyter-scheduler
+      commands:
+        - pip check
+      requires:
+        - pip
 
   - name: jupyter_scheduler
-  requirements:
-    host:
-      - python >=3.7
-      - hatchling >=1.3.1
-      - jupyterlab >=4.0,<5
-      - pip
-      - hatch-jupyter-builder
-    run:
-      - python >=3.7
-      - jupyter_server >=1.6,<3
-      - traitlets >=5.0,<6
-      - nbconvert >=7.0,<8
-      - pydantic >=1.10,<2
-      - sqlalchemy >=1.0,<2
-      - croniter >=1.4,<2
-      - pytz ==2023.3
-      - fsspec ==2023.6.0
-      - s3fs ==2023.6.0
-      - psutil >=5.9,<6
-  test:
-    imports:
-      - jupyter_scheduler
-    commands:
-      - pip check
-    requires:
-      - pip
+    requirements:
+      host:
+        - python >=3.7
+        - hatchling >=1.3.1
+        - jupyterlab >=4.0,<5
+        - pip
+        - hatch-jupyter-builder
+      run:
+        - python >=3.7
+        - jupyter_server >=1.6,<3
+        - traitlets >=5.0,<6
+        - nbconvert >=7.0,<8
+        - pydantic >=1.10,<2
+        - sqlalchemy >=1.0,<2
+        - croniter >=1.4,<2
+        - pytz ==2023.3
+        - fsspec ==2023.6.0
+        - s3fs ==2023.6.0
+        - psutil >=5.9,<6
+    test:
+      imports:
+        - jupyter_scheduler
+      commands:
+        - pip check
+      requires:
+        - pip
 
 about:
   summary: A JupyterLab extension for running notebook jobs

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,13 +11,6 @@ source:
 
 build:
   number: 1
-  missing_dso_whitelist:  
-    - /lib64/libpthread.so.0
-    - /lib64/libc.so.6
-    - /lib64/libm.so.6
-    - /lib64/ld-linux-x86-64.so.2
-    - "*/libstdc++.so.6"
-    - "*/libgcc_s.so.1"
 
 outputs:
   - name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
   number: 1
-`
+
 outputs:
   - name: jupyter-scheduler
   requirements:
@@ -42,7 +42,7 @@ outputs:
       - pip check
     requires:
       - pip
-      
+
   - name: jupyter_scheduler
   requirements:
     host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,8 @@ build:
     - /lib64/libc.so.6
     - /lib64/libm.so.6
     - /lib64/ld-linux-x86-64.so.2
+    - "*/libstdc++.so.6"
+    - "*/libgcc_s.so.1"
 
 outputs:
   - name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,13 +18,13 @@ outputs:
       script: python -m pip install . -vv
     requirements:
       host:
-        - python >=3.7
+        - python >=3.7,<3.12
         - hatchling >=1.3.1
         - jupyterlab >=4.0,<5
         - pip
         - hatch-jupyter-builder
       run:
-        - python >=3.7
+        - python >=3.7,<3.12
         - jupyter_server >=1.6,<3
         - traitlets >=5.0,<6
         - nbconvert >=7.0,<8
@@ -49,13 +49,13 @@ outputs:
       script: python -m pip install . -vv
     requirements:
       host:
-        - python >=3.7
+        - python >=3.7,<3.12
         - hatchling >=1.3.1
         - jupyterlab >=4.0,<5
         - pip
         - hatch-jupyter-builder
       run:
-        - python >=3.7
+        - python >=3.7,<3.12
         - jupyter_server >=1.6,<3
         - traitlets >=5.0,<6
         - nbconvert >=7.0,<8

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,6 +36,8 @@ outputs:
         - fsspec ==2023.6.0
         - s3fs ==2023.6.0
         - psutil >=5.9,<6
+        - libgcc-ng
+        - libstdcxx-ng
     test:
       imports:
         - jupyter_scheduler


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* N/A Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Fixes #4.

<!--
Please add any other relevant info below:
-->
- Add outputs section specifying both `jupyter_scheduler` and `jupyter-scheduler` packages to be built from this PR to streamline package naming, provide consistent user experience with pip
- Add upper bound to Python version specifier to be below 3.12 to avoid conflicts with `aiohttp` (transitive dependency)
- Add `libgcc-ng` and `libstdcxx-ng ` (runtime dependencies of the GNU Compiler Collection (GCC)) to runtime dependencies to ensure compiled components work in all environments including linux, linux build on Azure goes through  
- Add  `missing_dso_whitelist ` section with `/lib64/libpthread.so.0, /lib64/libc.so.6, /lib64/libm.so.6, /lib64/ld-linux-x86-64.so.2 ` linux system libraries to ensure absence of linking errors during build due to more precise linking checking when `outputs` section is used
- Rerender the feedstock