### PR TITLE
[1.x] add outputs section, produce both jupyter_scheduler and jupyter-scheduler packages

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -2,5 +2,5 @@ github:
   branch_name: main
   tooling_branch_name: main
 conda_build:
-  error_overlinking: true
+  error_overlinking: false
 conda_forge_output_validation: true

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set name = "jupyter_scheduler" %}
-{% set version = "2.1.0" %}
+{% set name = "jupyter-scheduler" %}
+{% set version = "1.4.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/jupyter_scheduler-{{ version }}.tar.gz
-  sha256: 0e928e9a07566b7b8d781169f5fa1bcd9e7ae196317d4a433b692802bed499e6
+  sha256: 64d9123b73a5f42efc7ab7ea33209c68644e7785cde7a383595c2ee4dd158822
 
 build:
   noarch: python
@@ -18,7 +18,7 @@ requirements:
   host:
     - python >=3.7
     - hatchling >=1.3.1
-    - jupyterlab >=4.0,<5
+    - jupyterlab >=3.1,<4
     - pip
     - hatch-jupyter-builder
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set name = "jupyter-scheduler" %}
+{% set name = "jupyter_scheduler" %}
 {% set version = "1.4.0" %}
 
 package:
@@ -10,37 +10,49 @@ source:
   sha256: 64d9123b73a5f42efc7ab7ea33209c68644e7785cde7a383595c2ee4dd158822
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
-  number: 0
+  number: 1
 
-requirements:
-  host:
-    - python >=3.7
-    - hatchling >=1.3.1
-    - jupyterlab >=3.1,<4
-    - pip
-    - hatch-jupyter-builder
-  run:
-    - python >=3.7
-    - jupyter_server >=1.6,<3
-    - traitlets >=5.0,<6
-    - nbconvert >=7.0,<8
-    - pydantic >=1.10,<2
-    - sqlalchemy >=1.0,<2
-    - croniter >=1.4,<2
-    - pytz ==2023.3
-    - fsspec ==2023.6.0
-    - s3fs ==2023.6.0
-    - psutil >=5.9,<6
+outputs:
+  - name: {{ name }}
+    build:
+      noarch: python
+      script: python -m pip install . -vv
+    requirements:
+      host:
+        - python >=3.7
+        - hatchling >=1.3.1
+        - jupyterlab >=3.1,<4
+        - pip
+        - hatch-jupyter-builder
+      run:
+        - python >=3.7
+        - jupyter_server >=1.6,<3
+        - traitlets >=5.0,<6
+        - nbconvert >=7.0,<8
+        - pydantic >=1.10,<2
+        - sqlalchemy >=1.0,<2
+        - croniter >=1.4,<2
+        - pytz ==2023.3
+        - fsspec ==2023.6.0
+        - s3fs ==2023.6.0
+        - psutil >=5.9,<6
+    test:
+      imports:
+        - jupyter_scheduler
+      commands:
+        - pip check
+      requires:
+        - pip
 
-test:
-  imports:
-    - jupyter_scheduler
-  commands:
-    - pip check
-  requires:
-    - pip
+  - name: jupyter-scheduler
+    build:
+      noarch: python
+    requirements:
+      run:
+        - {{ pin_subpackage(name, exact=True) }}
+    test:
+      imports:
+        - jupyter_scheduler
 
 about:
   summary: A JupyterLab extension for running notebook jobs


### PR DESCRIPTION
Backports https://github.com/conda-forge/jupyter_scheduler-feedstock/pull/5 to 1.x

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
