### PR TITLE
[1.x] add outputs section, produce both jupyter_scheduler and jupyter-scheduler packages

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -6,3 +6,5 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+target_platform:
+- linux-64

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -4,6 +4,10 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 target_platform:

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -34,7 +34,7 @@ CONDARC
 mamba install --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
     pip mamba conda-build boa conda-forge-ci-setup=3
 mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup
+    pip mamba conda-build boa conda-forge-ci-setup=3
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Current release info
 
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-jupyter--scheduler-green.svg)](https://anaconda.org/conda-forge/jupyter-scheduler) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/jupyter-scheduler.svg)](https://anaconda.org/conda-forge/jupyter-scheduler) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/jupyter-scheduler.svg)](https://anaconda.org/conda-forge/jupyter-scheduler) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/jupyter-scheduler.svg)](https://anaconda.org/conda-forge/jupyter-scheduler) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-jupyter_scheduler-green.svg)](https://anaconda.org/conda-forge/jupyter_scheduler) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/jupyter_scheduler.svg)](https://anaconda.org/conda-forge/jupyter_scheduler) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/jupyter_scheduler.svg)](https://anaconda.org/conda-forge/jupyter_scheduler) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/jupyter_scheduler.svg)](https://anaconda.org/conda-forge/jupyter_scheduler) |
 
 Installing jupyter_scheduler
@@ -39,41 +40,41 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `jupyter_scheduler` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `jupyter-scheduler, jupyter_scheduler` can be installed with `conda`:
 
 ```
-conda install jupyter_scheduler
-```
-
-or with `mamba`:
-
-```
-mamba install jupyter_scheduler
-```
-
-It is possible to list all of the versions of `jupyter_scheduler` available on your platform with `conda`:
-
-```
-conda search jupyter_scheduler --channel conda-forge
+conda install jupyter-scheduler jupyter_scheduler
 ```
 
 or with `mamba`:
 
 ```
-mamba search jupyter_scheduler --channel conda-forge
+mamba install jupyter-scheduler jupyter_scheduler
+```
+
+It is possible to list all of the versions of `jupyter-scheduler` available on your platform with `conda`:
+
+```
+conda search jupyter-scheduler --channel conda-forge
+```
+
+or with `mamba`:
+
+```
+mamba search jupyter-scheduler --channel conda-forge
 ```
 
 Alternatively, `mamba repoquery` may provide more information:
 
 ```
 # Search all versions available on your platform:
-mamba repoquery search jupyter_scheduler --channel conda-forge
+mamba repoquery search jupyter-scheduler --channel conda-forge
 
-# List packages depending on `jupyter_scheduler`:
-mamba repoquery whoneeds jupyter_scheduler --channel conda-forge
+# List packages depending on `jupyter-scheduler`:
+mamba repoquery whoneeds jupyter-scheduler --channel conda-forge
 
-# List dependencies of `jupyter_scheduler`:
-mamba repoquery depends jupyter_scheduler --channel conda-forge
+# List dependencies of `jupyter-scheduler`:
+mamba repoquery depends jupyter-scheduler --channel conda-forge
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-About jupyter_scheduler-feedstock
+About jupyter-scheduler-feedstock
 =================================
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/jupyter_scheduler-feedstock/blob/main/LICENSE.txt)
@@ -30,10 +30,10 @@ Current release info
 | [![Conda Recipe](https://img.shields.io/badge/recipe-jupyter--scheduler-green.svg)](https://anaconda.org/conda-forge/jupyter-scheduler) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/jupyter-scheduler.svg)](https://anaconda.org/conda-forge/jupyter-scheduler) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/jupyter-scheduler.svg)](https://anaconda.org/conda-forge/jupyter-scheduler) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/jupyter-scheduler.svg)](https://anaconda.org/conda-forge/jupyter-scheduler) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-jupyter_scheduler-green.svg)](https://anaconda.org/conda-forge/jupyter_scheduler) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/jupyter_scheduler.svg)](https://anaconda.org/conda-forge/jupyter_scheduler) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/jupyter_scheduler.svg)](https://anaconda.org/conda-forge/jupyter_scheduler) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/jupyter_scheduler.svg)](https://anaconda.org/conda-forge/jupyter_scheduler) |
 
-Installing jupyter_scheduler
+Installing jupyter-scheduler
 ============================
 
-Installing `jupyter_scheduler` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `jupyter-scheduler` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
 
 ```
 conda config --add channels conda-forge
@@ -119,17 +119,17 @@ Terminology
                   produce the finished article (built conda distributions)
 
 
-Updating jupyter_scheduler-feedstock
+Updating jupyter-scheduler-feedstock
 ====================================
 
-If you would like to improve the jupyter_scheduler recipe or build a new
+If you would like to improve the jupyter-scheduler recipe or build a new
 package version, please fork this repository and submit a PR. Upon submission,
 your changes will be run on the appropriate platforms to give the reviewer an
 opportunity to confirm that the changes result in a successful build. Once
 merged, the recipe will be re-built and uploaded automatically to the
 `conda-forge` channel, whereupon the built conda packages will be available for
 everybody to install and use from the `conda-forge` channel.
-Note that all branches in the conda-forge/jupyter_scheduler-feedstock are
+Note that all branches in the conda-forge/jupyter-scheduler-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
 on branches in forks and branches in the main repository should only be used to
 build distinct package versions.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-About jupyter-scheduler-feedstock
+About jupyter_scheduler-feedstock
 =================================
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/jupyter_scheduler-feedstock/blob/main/LICENSE.txt)
@@ -30,10 +30,10 @@ Current release info
 | [![Conda Recipe](https://img.shields.io/badge/recipe-jupyter--scheduler-green.svg)](https://anaconda.org/conda-forge/jupyter-scheduler) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/jupyter-scheduler.svg)](https://anaconda.org/conda-forge/jupyter-scheduler) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/jupyter-scheduler.svg)](https://anaconda.org/conda-forge/jupyter-scheduler) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/jupyter-scheduler.svg)](https://anaconda.org/conda-forge/jupyter-scheduler) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-jupyter_scheduler-green.svg)](https://anaconda.org/conda-forge/jupyter_scheduler) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/jupyter_scheduler.svg)](https://anaconda.org/conda-forge/jupyter_scheduler) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/jupyter_scheduler.svg)](https://anaconda.org/conda-forge/jupyter_scheduler) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/jupyter_scheduler.svg)](https://anaconda.org/conda-forge/jupyter_scheduler) |
 
-Installing jupyter-scheduler
+Installing jupyter_scheduler
 ============================
 
-Installing `jupyter-scheduler` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `jupyter_scheduler` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
 
 ```
 conda config --add channels conda-forge
@@ -119,17 +119,17 @@ Terminology
                   produce the finished article (built conda distributions)
 
 
-Updating jupyter-scheduler-feedstock
+Updating jupyter_scheduler-feedstock
 ====================================
 
-If you would like to improve the jupyter-scheduler recipe or build a new
+If you would like to improve the jupyter_scheduler recipe or build a new
 package version, please fork this repository and submit a PR. Upon submission,
 your changes will be run on the appropriate platforms to give the reviewer an
 opportunity to confirm that the changes result in a successful build. Once
 merged, the recipe will be re-built and uploaded automatically to the
 `conda-forge` channel, whereupon the built conda packages will be available for
 everybody to install and use from the `conda-forge` channel.
-Note that all branches in the conda-forge/jupyter-scheduler-feedstock are
+Note that all branches in the conda-forge/jupyter_scheduler-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
 on branches in forks and branches in the main repository should only be used to
 build distinct package versions.

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -2,5 +2,5 @@ github:
   branch_name: main
   tooling_branch_name: main
 conda_build:
-  error_overlinking: true
+  error_overlinking: false
 conda_forge_output_validation: true

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set name = "jupyter-scheduler" %}
+{% set name = "jupyter_scheduler" %}
 {% set version = "1.4.0" %}
 
 package:
@@ -10,7 +10,7 @@ source:
   sha256: 64d9123b73a5f42efc7ab7ea33209c68644e7785cde7a383595c2ee4dd158822
 
 build:
-  number: 1
+  number: 0
 
 outputs:
   - name: {{ name }}
@@ -19,6 +19,7 @@ outputs:
       script: python -m pip install . -vv
     requirements:
       host:
+        - {{ compiler('cxx') }}
         - python >=3.7,<3.12
         - hatchling >=1.3.1
         - jupyterlab >=3.1,<4
@@ -38,7 +39,7 @@ outputs:
         - psutil >=5.9,<6
     test:
       imports:
-        - jupyter-scheduler
+        - jupyter_scheduler
       commands:
         - pip check
       requires:
@@ -52,7 +53,7 @@ outputs:
         - {{ pin_subpackage(name, exact=True) }}
     test:
       imports:
-        - jupyter-scheduler
+        - jupyter_scheduler
 
 about:
   summary: A JupyterLab extension for running notebook jobs

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,7 @@ outputs:
       requires:
         - pip
 
-  - name: jupyter_scheduler
+  - name: jupyter-scheduler
     build:
       noarch: python
     requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set name = "jupyter-scheduler" %}
+{% set name = "jupyter_scheduler" %}
 {% set version = "1.4.0" %}
 
 package:
@@ -10,37 +10,49 @@ source:
   sha256: 64d9123b73a5f42efc7ab7ea33209c68644e7785cde7a383595c2ee4dd158822
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
-  number: 0
+  number: 1
 
-requirements:
-  host:
-    - python >=3.7
-    - hatchling >=1.3.1
-    - jupyterlab >=3.1,<4
-    - pip
-    - hatch-jupyter-builder
-  run:
-    - python >=3.7
-    - jupyter_server >=1.6,<3
-    - traitlets >=5.0,<6
-    - nbconvert >=7.0,<8
-    - pydantic >=1.10,<2
-    - sqlalchemy >=1.0,<2
-    - croniter >=1.4,<2
-    - pytz ==2023.3
-    - fsspec ==2023.6.0
-    - s3fs ==2023.6.0
-    - psutil >=5.9,<6
+outputs:
+  - name: {{ name }}
+    build:
+      noarch: python
+      script: python -m pip install . -vv
+    requirements:
+      host:
+        - python >=3.7
+        - hatchling >=1.3.1
+        - jupyterlab >=3.1,<4
+        - pip
+        - hatch-jupyter-builder
+      run:
+        - python >=3.7
+        - jupyter_server >=1.6,<3
+        - traitlets >=5.0,<6
+        - nbconvert >=7.0,<8
+        - pydantic >=1.10,<2
+        - sqlalchemy >=1.0,<2
+        - croniter >=1.4,<2
+        - pytz ==2023.3
+        - fsspec ==2023.6.0
+        - s3fs ==2023.6.0
+        - psutil >=5.9,<6
+    test:
+      imports:
+        - jupyter_scheduler
+      commands:
+        - pip check
+      requires:
+        - pip
 
-test:
-  imports:
-    - jupyter_scheduler
-  commands:
-    - pip check
-  requires:
-    - pip
+  - name: jupyter-scheduler
+    build:
+      noarch: python
+    requirements:
+      run:
+        - {{ pin_subpackage(name, exact=True) }}
+    test:
+      imports:
+        - jupyter_scheduler
 
 about:
   summary: A JupyterLab extension for running notebook jobs

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set name = "jupyter_scheduler" %}
+{% set name = "jupyter-scheduler" %}
 {% set version = "1.4.0" %}
 
 package:
@@ -38,13 +38,13 @@ outputs:
         - psutil >=5.9,<6
     test:
       imports:
-        - jupyter_scheduler
+        - jupyter-scheduler
       commands:
         - pip check
       requires:
         - pip
 
-  - name: jupyter-scheduler
+  - name: jupyter_scheduler
     build:
       noarch: python
     requirements:
@@ -52,7 +52,7 @@ outputs:
         - {{ pin_subpackage(name, exact=True) }}
     test:
       imports:
-        - jupyter_scheduler
+        - jupyter-scheduler
 
 about:
   summary: A JupyterLab extension for running notebook jobs

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,13 +19,13 @@ outputs:
       script: python -m pip install . -vv
     requirements:
       host:
-        - python >=3.7
+        - python >=3.7,<3.12
         - hatchling >=1.3.1
         - jupyterlab >=3.1,<4
         - pip
         - hatch-jupyter-builder
       run:
-        - python >=3.7
+        - python >=3.7,<3.12
         - jupyter_server >=1.6,<3
         - traitlets >=5.0,<6
         - nbconvert >=7.0,<8


### PR DESCRIPTION
Backports https://github.com/conda-forge/jupyter_scheduler-feedstock/pull/5 to 1.x

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
